### PR TITLE
Follow jest color conventions

### DIFF
--- a/src/__snapshots__/matcher.test.js.snap
+++ b/src/__snapshots__/matcher.test.js.snap
@@ -1,39 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`formats a message 1`] = `
-"[31m- Expected[39m
-[32m+ Received[39m
+"[32m- Expected[39m
+[31m+ Received[39m
 
-[90m  [39m
+[2m  [22m
 [37m-     .css-1otybxc,[39m
 [37m-     [data-css-1otybxc] {[39m
 [37m+     .css-i77z7r,[39m
 [37m+     [data-css-i77z7r] {[39m
-[90m        padding: 4em;[39m
-[31m-       background: papayawhip;[39m
-[32m+       background: blue;[39m
-[90m      }[39m
-[90m  [39m
+[2m        padding: 4em;[22m
+[32m-       background: papayawhip;[39m
+[31m+       background: blue;[39m
+[2m      }[22m
+[2m  [22m
 [37m-     .css-1tnuino,[39m
 [37m-     [data-css-1tnuino] {[39m
 [37m+     .css-1252hns,[39m
 [37m+     [data-css-1252hns] {[39m
-[90m        font-size: 1.5em;[39m
-[31m-       text-align: center;[39m
-[32m+       text-align: left;[39m
-[90m        color: palevioletred;[39m
-[90m      }[39m
-[90m  [39m
-[90m      <section[39m
+[2m        font-size: 1.5em;[22m
+[32m-       text-align: center;[39m
+[31m+       text-align: left;[39m
+[2m        color: palevioletred;[22m
+[2m      }[22m
+[2m  [22m
+[2m      <section[22m
 [37m-       className=\\"css-1otybxc\\"[39m
 [37m+       className=\\"css-i77z7r\\"[39m
-[90m      >[39m
-[90m        <h1[39m
+[2m      >[22m
+[2m        <h1[22m
 [37m-         className=\\"css-1tnuino\\"[39m
 [37m+         className=\\"css-1252hns\\"[39m
-[90m        >[39m
-[90m          Hello World, this is my first glamor styled component![39m
-[90m        </h1>[39m
-[90m      </section>[39m
-[90m    [39m"
+[2m        >[22m
+[2m          Hello World, this is my first glamor styled component![22m
+[2m        </h1>[22m
+[2m      </section>[22m
+[2m    [22m"
 `;

--- a/src/matcher.js
+++ b/src/matcher.js
@@ -25,12 +25,12 @@ const colorize = message =>
         return chalk.white(line)
       }
       if (isAddition(line)) {
-        return chalk.green(line)
-      }
-      if (isDeletion(line)) {
         return chalk.red(line)
       }
-      return chalk.gray(line)
+      if (isDeletion(line)) {
+        return chalk.green(line)
+      }
+      return chalk.dim(line)
     })
     .join('\n')
 


### PR DESCRIPTION
Hello @kentcdodds, this morning I [realized](https://github.com/facebook/jest/pull/1458#r75376801) Jest uses red for additions, and green for deletions.
Also, it uses `dim` for non-changed lines instead of gray.