### PR TITLE
Check that val exists before accessing keys

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -6,7 +6,8 @@ const serializer = {test, print}
 module.exports = serializer
 
 function test(val) {
-  return val && !val.withStyles && val.$$typeof === Symbol.for('react.test.json')
+  return val && !val.withStyles &&
+    val.$$typeof === Symbol.for('react.test.json')
 }
 
 function print(val, printer) {

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -6,7 +6,7 @@ const serializer = {test, print}
 module.exports = serializer
 
 function test(val) {
-  return !val.withStyles && val.$$typeof === Symbol.for('react.test.json')
+  return val && !val.withStyles && val.$$typeof === Symbol.for('react.test.json')
 }
 
 function print(val, printer) {


### PR DESCRIPTION
When `test`'s `val` is undefined the function throws an error and does not allow the test to finish. Therefore none of the `snapshots` would be tested/updated. Adding this seemed to help.

I am setting this up to be used with `react storybook storyshots`. All the `storyshots` failed to be tested and created because some of the values passed to the `test` function were undefined.