### PR TITLE
feat(serializer): support providing a custom StyleSheet instance

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -29,6 +29,17 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "mitchellhamilton",
+      "name": "Mitchell Hamilton",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/11481355?v=3",
+      "profile": "https://hamil.town",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Jest utilities for Glamor and React
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -155,6 +155,43 @@ test('enzyme', () => {
 })
 ```
 
+If you use a library with a similar stylesheet solution to [`glamor`][glamor] like [`cxs`][cxs] you can do this instead:
+
+```javascript
+import {sheet} from 'cxs'
+import {matcher, serializer} from 'jest-glamor-react'
+
+expect.addSnapshotSerializer(serializer(sheet))
+expect.extend(matcher)
+```
+
+Then you can create components like this:
+
+```javascript
+import React from 'react'
+import cxs from 'cxs'
+
+function Wrapper(props) {
+  const className = cxs({
+    padding: '4em',
+    background: 'papayawhip',
+  })
+  return <section className={`${className}`} {...props} />
+}
+
+function Title(props) {
+  const className = cxs({
+    fontSize: '1.5em',
+    textAlign: 'center',
+    color: 'palevioletred',
+  })
+  return <h1 className={`${className}`} {...props} />
+}
+```
+
+And test them the same way as before.
+
+
 ## Inspiration
 
 As mentioned earlier, [@MicheleBertoli][MicheleBertoli]'s
@@ -171,8 +208,8 @@ I'm unaware of other solutions. Please file a PR if you know of any!
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars1.githubusercontent.com/u/1308971?v=3" width="100px;"/><br /><sub>Michele Bertoli</sub>](http://michele.berto.li)<br />[💻](https://github.com/kentcdodds/jest-glamor-react/commits?author=MicheleBertoli) [📖](https://github.com/kentcdodds/jest-glamor-react/commits?author=MicheleBertoli) [⚠️](https://github.com/kentcdodds/jest-glamor-react/commits?author=MicheleBertoli) | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/jest-glamor-react/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/jest-glamor-react/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/jest-glamor-react/commits?author=kentcdodds) |
-| :---: | :---: |
+| [<img src="https://avatars1.githubusercontent.com/u/1308971?v=3" width="100px;"/><br /><sub>Michele Bertoli</sub>](http://michele.berto.li)<br />[💻](https://github.com/kentcdodds/jest-glamor-react/commits?author=MicheleBertoli) [📖](https://github.com/kentcdodds/jest-glamor-react/commits?author=MicheleBertoli) [⚠️](https://github.com/kentcdodds/jest-glamor-react/commits?author=MicheleBertoli) | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/jest-glamor-react/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/jest-glamor-react/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/jest-glamor-react/commits?author=kentcdodds) | [<img src="https://avatars2.githubusercontent.com/u/11481355?v=3" width="100px;"/><br /><sub>Mitchell Hamilton</sub>](https://hamil.town)<br />[💻](https://github.com/kentcdodds/jest-glamor-react/commits?author=mitchellhamilton) [📖](https://github.com/kentcdodds/jest-glamor-react/commits?author=mitchellhamilton) [⚠️](https://github.com/kentcdodds/jest-glamor-react/commits?author=mitchellhamilton) |
+| :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!
@@ -218,3 +255,4 @@ MIT
 [jest]: http://facebook.github.io/jest/
 [MicheleBertoli]: https://github.com/MicheleBertoli
 [jest-styled-components]: https://github.com/styled-components/jest-styled-components
+[cxs]: https://www.npmjs.com/package/cxs

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-register": "^6.23.0",
     "codecov": "^2.1.0",
     "commitizen": "^2.9.6",
+    "cxs": "^3.0.4",
     "cz-conventional-changelog": "^2.0.0",
     "enzyme": "^2.7.1",
     "enzyme-to-json": "^1.5.0",

--- a/src/__snapshots__/custom-sheet.test.js.snap
+++ b/src/__snapshots__/custom-sheet.test.js.snap
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. general tests: media queries - {"fontSize":24,"margin":12,"@media (max-width: 641px)":{"fontSize":20,"margin":10}} 1`] = `
+.fs-24 {
+  font-size: 24px;
+}
+
+.m-12 {
+  margin: 12px;
+}
+
+@media (max-width: 641px) {
+  ._9gzisy {
+    font-size: 20px;
+  }
+}
+
+@media (max-width: 641px) {
+  ._d2w6i1 {
+    margin: 10px;
+  }
+}
+
+<div
+  className="fs-24 m-12 _9gzisy _d2w6i1"
+/>
+`;
+
+exports[`2. general tests: pseudo elements - {"& button":{"color":"green"}} 1`] = `
+.___button-c-green & button {
+  color: green;
+}
+
+<div
+  className="___button-c-green"
+/>
+`;
+
+exports[`3. general tests: pseudo states - {":hover":{"backgroundColor":"blue"}} 1`] = `
+._hover-bc-blue:hover {
+  background-color: blue;
+}
+
+<div
+  className="_hover-bc-blue"
+/>
+`;
+
+exports[`doesn't mess up stuff that does't have styles 1`] = `<div />`;
+
+exports[`enzyme.mount 1`] = `
+.p-4em {
+  padding: 4em;
+}
+
+.b-papayawhip {
+  background: papayawhip;
+}
+
+.fs-1p5em {
+  font-size: 1.5em;
+}
+
+.text-align-center {
+  text-align: center;
+}
+
+.c-palevioletred {
+  color: palevioletred;
+}
+
+<Wrapper>
+  <section
+    className="p-4em b-papayawhip"
+  >
+    <Title>
+      <h1
+        className="fs-1p5em text-align-center c-palevioletred"
+      >
+        Hello World, this is my first glamor styled component!
+      </h1>
+    </Title>
+  </section>
+</Wrapper>
+`;
+
+exports[`enzyme.render 1`] = `
+.p-4em {
+  padding: 4em;
+}
+
+.b-papayawhip {
+  background: papayawhip;
+}
+
+.fs-1p5em {
+  font-size: 1.5em;
+}
+
+.text-align-center {
+  text-align: center;
+}
+
+.c-palevioletred {
+  color: palevioletred;
+}
+
+<section
+  class="p-4em b-papayawhip"
+>
+  <h1
+    class="fs-1p5em text-align-center c-palevioletred"
+  >
+    Hello World, this is my first glamor styled component!
+  </h1>
+</section>
+`;
+
+exports[`enzyme.shallow 1`] = `
+.p-4em {
+  padding: 4em;
+}
+
+.b-papayawhip {
+  background: papayawhip;
+}
+
+<section
+  className="p-4em b-papayawhip"
+>
+  <Title>
+    Hello World, this is my first glamor styled component!
+  </Title>
+</section>
+`;
+
+exports[`react-test-renderer 1`] = `
+.p-4em {
+  padding: 4em;
+}
+
+.b-papayawhip {
+  background: papayawhip;
+}
+
+.fs-1p5em {
+  font-size: 1.5em;
+}
+
+.text-align-center {
+  text-align: center;
+}
+
+.c-palevioletred {
+  color: palevioletred;
+}
+
+<section
+  className="p-4em b-papayawhip"
+>
+  <h1
+    className="fs-1p5em text-align-center c-palevioletred"
+  >
+    Hello World, this is my first glamor styled component!
+  </h1>
+</section>
+`;
+
+exports[`works when the root element does not have styles 1`] = `
+.p-4em {
+  padding: 4em;
+}
+
+.b-papayawhip {
+  background: papayawhip;
+}
+
+<div>
+  <section
+    className="p-4em b-papayawhip"
+  />
+</div>
+`;

--- a/src/custom-sheet.test.js
+++ b/src/custom-sheet.test.js
@@ -1,0 +1,109 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import cxs, {sheet} from 'cxs'
+import * as enzyme from 'enzyme'
+import toJson from 'enzyme-to-json'
+import {matcher, serializer} from '../src'
+
+expect.addSnapshotSerializer(serializer(sheet))
+expect.extend(matcher)
+
+function Wrapper(props) {
+  const className = cxs({
+    padding: '4em',
+    background: 'papayawhip',
+  })
+  return <section className={`${className}`} {...props} />
+}
+
+function Title(props) {
+  const className = cxs({
+    fontSize: '1.5em',
+    textAlign: 'center',
+    color: 'palevioletred',
+  })
+  return <h1 className={`${className}`} {...props} />
+}
+
+test('react-test-renderer', () => {
+  const tree = renderer
+    .create(
+      <Wrapper>
+        <Title>Hello World, this is my first glamor styled component!</Title>
+      </Wrapper>,
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshotWithGlamor()
+})
+
+test('enzyme', () => {
+  const ui = (
+    <Wrapper>
+      <Title>Hello World, this is my first glamor styled component!</Title>
+    </Wrapper>
+  )
+
+  const enzymeMethods = ['shallow', 'mount', 'render']
+  enzymeMethods.forEach(method => {
+    const tree = enzyme[method](ui)
+    expect(toJson(tree)).toMatchSnapshotWithGlamor(`enzyme.${method}`)
+  })
+})
+
+test('works when the root element does not have styles', () => {
+  const tree = renderer
+    .create(
+      <div>
+        <Wrapper />
+      </div>,
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshotWithGlamor()
+})
+
+test(`doesn't mess up stuff that does't have styles`, () => {
+  const tree = renderer.create(<div />).toJSON()
+
+  expect(tree).toMatchSnapshotWithGlamor()
+})
+
+const generalTests = [
+  {
+    title: 'media queries',
+    styles: {
+      fontSize: 24,
+      margin: 12,
+      '@media (max-width: 641px)': {
+        fontSize: 20,
+        margin: 10,
+      },
+    },
+  },
+  {
+    title: 'pseudo elements',
+    styles: {
+      '& button': {
+        color: 'green',
+      },
+    },
+  },
+  {
+    title: 'pseudo states',
+    styles: {
+      ':hover': {
+        backgroundColor: 'blue',
+      },
+    },
+  },
+]
+
+generalTests.forEach(({title, styles}, index) => {
+  test(title, () => {
+    const tree = renderer.create(<div className={cxs(styles)} />)
+    expect(tree).toMatchSnapshotWithGlamor(
+      `${index + 1}. general tests: ${title} - ${JSON.stringify(styles)}`,
+    )
+  })
+})

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -1,98 +1,104 @@
 const css = require('css')
-const {styleSheet} = require('glamor')
+const {styleSheet: glamorStyleSheet} = require('glamor')
 
-const serializer = {test, print}
-
-module.exports = serializer
-
-function test(val) {
-  return val && !val.withStyles &&
-    val.$$typeof === Symbol.for('react.test.json')
-}
-
-function print(val, printer) {
-  const selectors = getSelectors(val)
-  const styles = getStyles(selectors)
-  val.withStyles = true
-  const printedVal = printer(val)
-  if (styles) {
-    return `${styles}\n\n${printedVal}`
-  } else {
-    return printedVal
+function createSerializer(styleSheet) {
+  function test(val) {
+    return val &&
+      !val.withStyles &&
+      val.$$typeof === Symbol.for('react.test.json')
   }
-}
 
-function getSelectors(node) {
-  let selectors = []
-  if (node.children && node.children.reduce) {
-    selectors = node.children.reduce(
-      (acc, child) => acc.concat(getSelectors(child)),
+  function print(val, printer) {
+    const selectors = getSelectors(val)
+    const styles = getStyles(selectors)
+    val.withStyles = true
+    const printedVal = printer(val)
+    if (styles) {
+      return `${styles}\n\n${printedVal}`
+    } else {
+      return printedVal
+    }
+  }
+
+  function getSelectors(node) {
+    let selectors = []
+    if (node.children && node.children.reduce) {
+      selectors = node.children.reduce(
+        (acc, child) => acc.concat(getSelectors(child)),
+        [],
+      )
+    }
+    if (node.props) {
+      return getSelectorsFromProps(selectors, node.props)
+    }
+    return selectors
+  }
+
+  function getSelectorsFromProps(selectors, props) {
+    const className = props.className || props.class
+    if (className) {
+      selectors = selectors.concat(
+        className.toString().split(' ').map(cn => `.${cn}`),
+      )
+    }
+    const dataProps = Object.keys(props).reduce(
+      (dProps, key) => {
+        if (key.startsWith('data-')) {
+          dProps.push(`[${key}]`)
+        }
+        return dProps
+      },
       [],
     )
+    if (dataProps.length) {
+      selectors = selectors.concat(dataProps)
+    }
+    return selectors
   }
-  if (node.props) {
-    return getSelectorsFromProps(selectors, node.props)
-  }
-  return selectors
-}
 
-function getSelectorsFromProps(selectors, props) {
-  const className = props.className || props.class
-  if (className) {
-    selectors = selectors.concat(
-      className.toString().split(' ').map(cn => `.${cn}`),
-    )
-  }
-  const dataProps = Object.keys(props).reduce(
-    (dProps, key) => {
-      if (key.startsWith('data-')) {
-        dProps.push(`[${key}]`)
+  function getStyles(nodeSelectors) {
+    const styles = styleSheet.tags
+      .map(tag => /* istanbul ignore next */ tag.textContent || '')
+      .join('\n')
+    const ast = css.parse(styles)
+    const rules = ast.stylesheet.rules.filter(filter)
+    const mediaQueries = getMediaQueries(ast, filter)
+
+    ast.stylesheet.rules = [...rules, ...mediaQueries]
+
+    const ret = css.stringify(ast)
+    return ret
+
+    function filter(rule) {
+      if (rule.type === 'rule') {
+        return rule.selectors.some(selector => {
+          const baseSelector = selector.split(/:| /)[0]
+          return nodeSelectors.includes(baseSelector)
+        })
       }
-      return dProps
-    },
-    [],
-  )
-  if (dataProps.length) {
-    selectors = selectors.concat(dataProps)
-  }
-  return selectors
-}
-
-function getStyles(nodeSelectors) {
-  const styles = styleSheet.tags
-    .map(tag => /* istanbul ignore next */ tag.textContent || '')
-    .join('\n')
-  const ast = css.parse(styles)
-  const rules = ast.stylesheet.rules.filter(filter)
-  const mediaQueries = getMediaQueries(ast, filter)
-
-  ast.stylesheet.rules = [...rules, ...mediaQueries]
-
-  const ret = css.stringify(ast)
-  return ret
-
-  function filter(rule) {
-    if (rule.type === 'rule') {
-      return rule.selectors.some(selector => {
-        const baseSelector = selector.split(/:| /)[0]
-        return nodeSelectors.includes(baseSelector)
-      })
+      return false
     }
-    return false
   }
+
+  function getMediaQueries(ast, filter) {
+    return ast.stylesheet.rules.filter(rule => rule.type === 'media').reduce((
+      acc,
+      mediaQuery,
+    ) => {
+      mediaQuery.rules = mediaQuery.rules.filter(filter)
+
+      if (mediaQuery.rules.length) {
+        return acc.concat(mediaQuery)
+      }
+
+      return acc
+    }, [])
+  }
+  return {test, print}
 }
 
-function getMediaQueries(ast, filter) {
-  return ast.stylesheet.rules.filter(rule => rule.type === 'media').reduce((
-    acc,
-    mediaQuery,
-  ) => {
-    mediaQuery.rules = mediaQuery.rules.filter(filter)
+const glamorSerializer = createSerializer(glamorStyleSheet)
+createSerializer.test = glamorSerializer.test
+createSerializer.print = glamorSerializer.print
 
-    if (mediaQuery.rules.length) {
-      return acc.concat(mediaQuery)
-    }
-
-    return acc
-  }, [])
-}
+module.exports = createSerializer

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,6 +1649,12 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+cxs@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cxs/-/cxs-3.0.4.tgz#2e1a1537742931a53dbe3157afbf121da62df797"
+  dependencies:
+    glamor "^2.17.14"
+
 cz-conventional-changelog@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz#2bca04964c8919b23f3fd6a89ef5e6008b31b3f8"
@@ -2665,7 +2671,7 @@ github@~0.1.10:
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/github/-/github-0.1.16.tgz#895d2a85b0feb7980d89ac0ce4f44dcaa03f17b5"
 
-glamor@^2.20.24:
+glamor@^2.17.14, glamor@^2.20.24:
   version "2.20.24"
   resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.24.tgz#a299af2eec687322634ba38e4a0854d8743d2041"
   dependencies:


### PR DESCRIPTION
**What**:

Let people pass in a custom `StyleSheet` instance to serializer.

**Why**:

So that people who use css-in-js solutions like `cxs` can use `jest-glamor-react` to test their components.

**How**:

I wrapped the current serializer in a function that accepts a `StyleSheet` instance and returns a serializer. To not break the current API I called the function with glamor's `styleSheet` and put those properties onto the function itself so it can be used in these two ways; first with glamor, second with any other `StyleSheet` like it.
```js
import { serializer } from 'jest-glamor-react'
expect.addSnapshotSerializer(serializer)
```
```js
import { serializer } from 'jest-glamor-react'
expect.addSnapshotSerializer(serializer(sheet))
```

For the tests, I copied the ones from `index.test.js` and modified them to use `cxs`.
In the README, I used `cxs` as an example.

Closes #5
Related: tkh44/emotion#21