### PR TITLE
Fix processing rules with additional appended classes, i.e. &.someclass

### DIFF
--- a/src/__snapshots__/custom-sheet.test.js.snap
+++ b/src/__snapshots__/custom-sheet.test.js.snap
@@ -46,6 +46,16 @@ exports[`3. general tests: pseudo states - {":hover":{"backgroundColor":"blue"}}
 />
 `;
 
+exports[`4. general tests: Appended class - {"&.button":{"color":"green"}} 1`] = `
+.__pbutton-c-green &.button {
+  color: green;
+}
+
+<div
+  className="__pbutton-c-green"
+/>
+`;
+
 exports[`doesn't mess up stuff that does't have styles 1`] = `<div />`;
 
 exports[`enzyme.mount 1`] = `

--- a/src/__snapshots__/serializer.test.js.snap
+++ b/src/__snapshots__/serializer.test.js.snap
@@ -67,6 +67,17 @@ exports[`5. general tests: supports queries - {"@supports (display: grid)":{"dis
 />
 `;
 
+exports[`6. general tests: Appended class - {"&.button":{"color":"green"}} 1`] = `
+.css-95zeve.button,
+[data-css-95zeve].button {
+  color: green;
+}
+
+<div
+  data-css-95zeve=""
+/>
+`;
+
 exports[`doesn't mess up stuff that does't have styles 1`] = `<div />`;
 
 exports[`enzyme.mount 1`] = `

--- a/src/custom-sheet.test.js
+++ b/src/custom-sheet.test.js
@@ -96,6 +96,14 @@ const generalTests = [
       },
     },
   },
+  {
+    title: 'Appended class',
+    styles: {
+      '&.button': {
+        color: 'green',
+      },
+    },
+  },
 ]
 
 generalTests.forEach(({title, styles}, index) => {

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -87,7 +87,7 @@ function createSerializer(styleSheet) {
     function filter(rule) {
       if (rule.type === 'rule') {
         return rule.selectors.some(selector => {
-          let baseSelector = selector.split(/:| |\./).filter(s => !!s)[0]
+          const baseSelector = selector.split(/:| |\./).filter(s => !!s)[0]
           return nodeSelectors.some(
             sel => sel === baseSelector || sel === `.${baseSelector}`,
           )

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -87,8 +87,10 @@ function createSerializer(styleSheet) {
     function filter(rule) {
       if (rule.type === 'rule') {
         return rule.selectors.some(selector => {
-          const baseSelector = selector.split(/:| /)[0]
-          return nodeSelectors.includes(baseSelector)
+          let baseSelector = selector.split(/:| |\./).filter(s => !!s)[0]
+          return nodeSelectors.some(
+            sel => sel === baseSelector || sel === `.${baseSelector}`,
+          )
         })
       }
       return false

--- a/src/serializer.test.js
+++ b/src/serializer.test.js
@@ -111,6 +111,14 @@ const generalTests = [
       },
     },
   },
+  {
+    title: 'Appended class',
+    styles: {
+      '&.button': {
+        color: 'green',
+      },
+    },
+  },
 ]
 
 generalTests.forEach(({title, styles}, index) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix the output when css rule have only something like this:
```css
  &.active {
    background:green;
  }
```
Previously it was skipped from output due to wrong filtering in ```getStyles()```

<!-- How were these changes implemented? -->
**How**:
See ```getStyles``` in ```serializer.js``` in PR

<!-- feel free to add additional comments -->
