### PR TITLE
Allow to provide custom class name replacer to serialize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ import serializer from 'jest-glamor-react'
 expect.addSnapshotSerializer(serializer(sheet))
 ```
 
+You can also pass custom class name replacer to serializer function:
+```javascript
+import {sheet} from 'cxs'
+import serializer from 'jest-glamor-react'
+
+function replaceClassNames(className, index) {
+  return `my-class-name-${index}`
+}
+
+expect.addSnapshotSerializer(serializer(sheet, replaceClassNames))
+```
+
+Class name replacer will receive original class name and class name index
+
+
 Then you can create components like this:
 
 ```javascript

--- a/src/replace-class-names.js
+++ b/src/replace-class-names.js
@@ -1,15 +1,29 @@
-const replaceClassNames = (selectors, styles, code) => {
+function defaultClassNameReplacer(className, index) {
+  return `glamor-${index}`
+}
+
+const replaceClassNames = (
+  selectors,
+  styles,
+  code,
+  replacer = defaultClassNameReplacer,
+) => {
   let index = 0
-  return selectors.reduce((acc, className) => {
-    if (className.indexOf('.css-') === 0) {
-      const escapedRegex = new RegExp(
-        className.replace('.', '').replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'),
-        'g',
-      )
-      return acc.replace(escapedRegex, `glamor-${index++}`)
-    }
-    return acc
-  }, `${styles}\n\n${code}`)
+  return selectors.reduce(
+    (acc, className) => {
+      if (className.indexOf('.css-') === 0) {
+        const escapedRegex = new RegExp(
+          className
+            .replace('.', '')
+            .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'),
+          'g',
+        )
+        return acc.replace(escapedRegex, replacer(className, index++))
+      }
+      return acc
+    },
+    `${styles}\n\n${code}`,
+  )
 }
 
 module.exports = {replaceClassNames}

--- a/src/replace-class-names.test.js
+++ b/src/replace-class-names.test.js
@@ -131,3 +131,41 @@ test('replaces css-label- classes', () => {
   expect(result).toMatch(/(glamor-0)/)
   expect(result).not.toMatch(/(css-label-12345)/)
 })
+
+test('replaces with custom class name replacer', () => {
+  const selectors = ['.css-12345', '.css-67890']
+  const styles = `
+    .css-12345,
+    [data-css-12345] {
+      font-size: 1.5em;
+      text-align: center;
+      color: palevioletred;
+    }
+
+    .css-67890,
+    [data-css-67890] {
+      font-size: 1.5em;
+      text-align: center;
+      color: palevioletred;
+    }
+  `
+  const code = `
+    <section
+      className="some-other-class css-12345"
+    >
+      <h1
+        className="changed-class css-67890"
+      >
+        Hello World, this is my first glamor styled component!
+      </h1>
+    </section>
+  `
+  const result = replaceClassNames(
+    selectors,
+    styles,
+    code,
+    (className, index) => `custom-${index}-${className.replace('.', '')}`,
+  )
+  expect(result).toMatch(/(custom-0-css-12345)/)
+  expect(result).toMatch(/(custom-1-css-67890)/)
+})

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -1,7 +1,7 @@
 const css = require('css')
 const {replaceClassNames} = require('./replace-class-names')
 
-function createSerializer(styleSheet) {
+function createSerializer(styleSheet, classNameReplacer) {
   function test(val) {
     return val &&
       !val.withStyles &&
@@ -15,7 +15,12 @@ function createSerializer(styleSheet) {
     const styles = getStyles(selectors)
     const printedVal = printer(val)
     if (styles) {
-      return replaceClassNames(selectors, styles, printedVal)
+      return replaceClassNames(
+        selectors,
+        styles,
+        printedVal,
+        classNameReplacer,
+      )
     } else {
       return printedVal
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Allow to provide custom class name replacer for serialize():
```js
serialize(sheet, className => `my-css-${className}`)
```

<!-- Why are these changes necessary? -->
**Why**:
This is very helpful if you have some babel plugin which appends component name to your class-names, i.e:
```js
const className = "css-12345-MyComponent";
const replacer = className => className.split("-").splice(-1)[0]; // MyComponent

serializer(sheet, replacer);
```


<!-- How were these changes implemented? -->
**How**: See PR


<!-- feel free to add additional comments -->
