### PR TITLE
Fixes placeholder classnames not working with child selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ dist
 .opt-in
 .opt-out
 
+# JetBrains IDE
+.idea
+
+# MacOs
+.DS_Store

--- a/src/__snapshots__/serializer.test.js.snap
+++ b/src/__snapshots__/serializer.test.js.snap
@@ -78,7 +78,31 @@ exports[`6. general tests: Appended class - {"&.button":{"color":"green"}} 1`] =
 />
 `;
 
+exports[`7. general tests: Child selector - {"> div":{"display":"inline-block"}} 1`] = `
+.css-v2yp9i> div,
+[data-css-v2yp9i]> div {
+  display: inline-block;
+}
+
+<div
+  data-css-v2yp9i=""
+/>
+`;
+
 exports[`doesn't mess up stuff that does't have styles 1`] = `<div />`;
+
+exports[`doesn't mess up stuff when styles have a child selector 1`] = `
+.css-v2yp9i> div,
+[data-css-v2yp9i]> div {
+  display: inline-block;
+}
+
+<div>
+  <span
+    data-css-v2yp9i=""
+  />
+</div>
+`;
 
 exports[`enzyme.mount 1`] = `
 .glamor-1,

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -73,6 +73,13 @@ function createSerializer(styleSheet, classNameReplacer) {
     return selectors
   }
 
+  function filterChildSelector(baseSelector) {
+    if (baseSelector.slice(-1) === '>') {
+      return baseSelector.slice(0, -1)
+    }
+    return baseSelector
+  }
+
   function getStyles(nodeSelectors) {
     const tags = typeof styleSheet === 'function' ?
       styleSheet().tags :
@@ -92,7 +99,9 @@ function createSerializer(styleSheet, classNameReplacer) {
     function filter(rule) {
       if (rule.type === 'rule') {
         return rule.selectors.some(selector => {
-          const baseSelector = selector.split(/:| |\./).filter(s => !!s)[0]
+          const baseSelector = filterChildSelector(
+            selector.split(/:| |\./).filter(s => !!s)[0],
+          )
           return nodeSelectors.some(
             sel => sel === baseSelector || sel === `.${baseSelector}`,
           )

--- a/src/serializer.test.js
+++ b/src/serializer.test.js
@@ -68,6 +68,18 @@ test(`doesn't mess up stuff that does't have styles`, () => {
   expect(tree).toMatchSnapshot()
 })
 
+test(`doesn't mess up stuff when styles have a child selector`, () => {
+  const style = glamor.css({
+    '> div': {
+      display: 'inline-block',
+    },
+  })
+
+  const tree = renderer.create(<div><span {...style} /></div>).toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
 const generalTests = [
   {
     title: 'data attributes',
@@ -116,6 +128,14 @@ const generalTests = [
     styles: {
       '&.button': {
         color: 'green',
+      },
+    },
+  },
+  {
+    title: 'Child selector',
+    styles: {
+      '> div': {
+        display: 'inline-block',
       },
     },
   },


### PR DESCRIPTION
**What**: This fixes issue #24 

**Why**: If the child selector is present on the baseSelector it will prevent the placeholder classnames from working.

**How**: Added a filter that will look at the end of the baseSelector to see if a child selector is present, If present it will strip the selector off.